### PR TITLE
Add keywords to the slack bot message.

### DIFF
--- a/Actor.SlackPublisher/Actor.SlackPublisher.csproj
+++ b/Actor.SlackPublisher/Actor.SlackPublisher.csproj
@@ -80,6 +80,7 @@
       <Link>Properties\SolutionAssemblyInfo.cs</Link>
     </Compile>
     <Compile Include="AppSettings.cs" />
+    <Compile Include="MatchInfo.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Slack.cs" />
     <Compile Include="SlackPublisher.cs" />

--- a/Actor.SlackPublisher/App.config
+++ b/Actor.SlackPublisher/App.config
@@ -5,13 +5,14 @@
   </startup>
 
   <appSettings>
-    <add key="http://jobs.dou.ua/vacancies/feeds/?category=.NET" value="F#, functional programming, monad, haskell, scala, clojure, cqrs, ddd, domain driven, reactive, event sourcing, actor, akka, akka.net, orleans" />
-    <add key="http://jobs.dou.ua/vacancies/feeds/?category=Java" value="F#, functional programming, monad, haskell, scala, clojure, cqrs, ddd, domain driven, reactive, event sourcing, actor, akka, akka.net, orleans" />
-    <add key="http://jobs.dou.ua/vacancies/feeds/?category=Scala" value="" />
+    <add key="http://jobs.dou.ua/vacancies/feeds/?category=.NET" value="F#, functional programming, monad, haskell, scala, clojure, cqrs, ddd, domain driven, reactive, event sourcing, actor, akka, akka.net, orleans"/>
+    <add key="http://jobs.dou.ua/vacancies/feeds/?category=Java" value="F#, functional programming, monad, haskell, scala, clojure, cqrs, ddd, domain driven, reactive, event sourcing, actor, akka, akka.net, orleans"/>
+    <add key="http://jobs.dou.ua/vacancies/feeds/?category=Scala" value=""/>
 
-    <add key="SlackHookUrl" value="https://hooks.slack.com/services/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" />
-    <add key="SlackHookName" value="functional-works" />
-    <add key="SlackHookEmoji" value=":curly_loop:" />
+    <add key="SlackHookUrl" value="https://hooks.slack.com/services/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"/>
+    <add key="SlackHookName" value="functional-works"/>
+    <add key="SlackHookEmoji" value=":curly_loop:"/>
+    <add key="KeywordColor" value="#36a64f"/>
     
   </appSettings>
 </configuration>

--- a/Actor.SlackPublisher/AppSettings.cs
+++ b/Actor.SlackPublisher/AppSettings.cs
@@ -9,5 +9,7 @@
         public static string SlackHookName { get; } = ConfigurationManager.AppSettings["SlackHookName"];
 
         public static string SlackHookEmoji { get; } = ConfigurationManager.AppSettings["SlackHookEmoji"];
+
+        public static string KeywordColor { get; } = ConfigurationManager.AppSettings["KeywordColor"];
     }
 }

--- a/Actor.SlackPublisher/MatchInfo.cs
+++ b/Actor.SlackPublisher/MatchInfo.cs
@@ -1,0 +1,24 @@
+﻿namespace SmartCrawler.Actor.SlackPublisher
+{
+    using System.Collections.Generic;
+    using System.Linq;
+
+    public class MatchInfo
+    {
+        public static MatchInfo SuccessfulEmpty = new MatchInfo { IsMatched = true, KeyWords = Enumerable.Empty<string>() };
+
+        private MatchInfo()
+        { }
+
+        public MatchInfo(IEnumerable<string> keyWords)
+            : this()
+        {
+            IsMatched = keyWords.Any();
+            KeyWords = keyWords;
+        }
+
+        public bool IsMatched { get; private set; }
+
+        public IEnumerable<string> KeyWords { get; private set; }
+    }
+}

--- a/Actor.SlackPublisher/Slack.cs
+++ b/Actor.SlackPublisher/Slack.cs
@@ -1,16 +1,18 @@
 ﻿namespace SmartCrawler.Actor.SlackPublisher
 {
     using System;
-
+    using System.Collections.Generic;
+    using System.Configuration;
+    using System.Linq;
     using Newtonsoft.Json;
 
     public static class Slack
     {
-        public static void Post(string message)
+        public static void Post(string message, IEnumerable<string> attachments = null)
         {
             try
             {                
-                var data = GetJson(message, AppSettings.SlackHookName, AppSettings.SlackHookEmoji);
+                var data = GetJson(message, AppSettings.SlackHookName, AppSettings.SlackHookEmoji, attachments);
                 HttpPost(AppSettings.SlackHookUrl, data);
             }
             catch (Exception)
@@ -35,9 +37,12 @@
             return sr.ReadToEnd().Trim();
         }
 
-        private static string GetJson(string text, string username, string icon_emoji)
+        private static string GetJson(string text, string username, string icon_emoji, IEnumerable<string> attachments = null)
         {
-            return JsonConvert.SerializeObject(new { text, username, icon_emoji });
+            var messageAttachments = attachments == null || !attachments.Any() ? 
+                null : 
+                new[] { new { text = string.Join(", ", attachments), color = AppSettings.KeywordColor } };
+            return JsonConvert.SerializeObject(new { text, username, icon_emoji, attachments = messageAttachments });
         }
     }
 }


### PR DESCRIPTION
Several times we tried to figure out why a job description had been posted to the
channel and searched particular keywords at the web site. Now matched keywords
if any are displayed as the message attachment.
